### PR TITLE
Minor suggestions.

### DIFF
--- a/_posts/2015-03-29-browser-as-an-interactive-disassembler.md
+++ b/_posts/2015-03-29-browser-as-an-interactive-disassembler.md
@@ -1,16 +1,16 @@
 ---
 layout: blogpost
-title: Browser as an Interactive Disassembler
+title: The Browser as an Interactive Disassembler
 date: 2015-03-29
 ---
 
-[The title of this post is intentionally a bit misleading - it should be *Browser as an Interactive Disassembly Exploration Tool* but that's way too confusing]
+[The title of this post is intentionally a bit misleading - it should be *The Browser as an Interactive Disassembly Exploration Tool* but that's way too confusing]
 
 Due to the nature of my work I often have to dig through disassembly listings. Usually these are spat out by a compiler I'm working or worked on, which makes it easy to recognize familiar patterns and reconstruct the flow of the program. Assemblers and disassemblers built into V8 and Dart VM additionally support embedded comments which makes reading their output even easier. However from time to time I have to read the code produced by a compiler I only have a passing familiarity with, for a example to find and work around [a bug](https://code.google.com/p/dart/source/detail?r=41581) or to better understand optimizations another compiler is capable of.
 
-It might seem backwards to start reviewing an optimization performed by some open-source compiler from the code it generates instead of locating it in the source and understanding the whole pass in all its generality. However compilers rarely resemble elegant and slick machines, they are more akin to mossy [steam-powered walking castles](http://m.imdb.com/title/tt0347149/mediaindex?rmconst=rm4085559296), a congregation of towers, parapets, turrets and bridges that grew around a once simple core and now is driven forward by a mess of pipes, pistons, boilers, valves, rods, wheels and gears. It's impossible to navigate a maze of compiler's implementation unless you have a lot of free time to spend inside, running some errands together with its maintenance crew.
+It might seem backwards to start reviewing an optimization performed by some open-source compiler from the code it generates instead of locating it in the source and understanding the whole pass in all its generality. However compilers rarely resemble elegant and slick machines, they are more akin to mossy [steam-powered walking castles](http://m.imdb.com/title/tt0347149/mediaindex?rmconst=rm4085559296), a congregation of towers, parapets, turrets and bridges that grew around a once simple core and now is driven forward by a mess of pipes, pistons, boilers, valves, rods, wheels and gears. It's impossible to navigate the maze of a compiler's implementation unless you have a lot of free time to spend inside, running some errands together with its maintenance crew.
 
-Reading compiler's output is much easier as you are often helped by the fact that most compilers only exist to optimize your code. They might move you code around, decompose and recombine it in unexpected ways but unlike [packers](http://en.wikipedia.org/wiki/Executable_compression) they are not going to waste CPU cycles to try and purposefully muddle the control and data flow inside it. The code produced by a compiler is usually well-behaved: it uses well-defined calling conventions, keeps stack balanced, does not self-modify at all or limits self-modification to certain sites.
+Reading a compiler's output is much easier as you are often helped by the fact that most compilers only exist to optimize your code. They might move you code around, decompose and recombine it in unexpected ways but unlike [packers](http://en.wikipedia.org/wiki/Executable_compression) they are not going to waste CPU cycles to try and purposefully muddle the control and data flow inside it. The code produced by a compiler is usually well-behaved: it uses well-defined calling conventions, keeps the stack balanced, does not self-modify at all or limits self-modification to certain sites.
 
 A couple of weeks ago I became interested in what kind of code HotSpot's C2 compiler (aka "opto", aka "server compiler") produces for the loop below
 
@@ -29,13 +29,13 @@ class SmallMap {
 }
 {% endhighlight %}
 
-This post documents a journey that started with a disassembly for this function and went sideways: with me implementing a interactive toy tool for disassembly exploration in the browser.
+This post documents a journey that started with a disassembly for this function and went sideways: with me implementing an interactive toy tool for disassembly exploration in the browser.
 
 You can play with the resulting tool called Saga (which is more like a larvae of a tool) [here](/saga/index.html).  It's source is currently [inside IRHydra repo](https://github.com/mraleph/irhydra/tree/master/saga). If you are just curious to learn what C2 did to the loop above skip to the very end of the post.
 
 ### Getting the disassembly out of HotSpot
 
-This is the easiest part. All you need is to [get](https://kenai.com/projects/base-hsdis/downloads) or to [build](https://github.com/AdoptOpenJDK/jitwatch/wiki/Building-hsdis) external disassembler library `hsdis`, place it somewhere JVM can find it (e.g. add its location to `LD_LIBRARY_PATH`) and run with `-XX:+UnlockDiagnosticVMOptions -XX:+PrintAssembly` command line flags. If you are like me and have your brain hardwired for Intel assembly syntax then you'll certainly also appreciate the existence of `-XX:PrintAssemblyOptions=intel` option.
+This is the easiest part. All you need is to [get](https://kenai.com/projects/base-hsdis/downloads) or to [build](https://github.com/AdoptOpenJDK/jitwatch/wiki/Building-hsdis) the external disassembler library `hsdis`, place it somewhere JVM can find it (e.g. add its location to `LD_LIBRARY_PATH`) and run with `-XX:+UnlockDiagnosticVMOptions -XX:+PrintAssembly` command line flags. If you are like me and have your brain hardwired to Intel assembly syntax then you'll certainly also appreciate the existence of the `-XX:PrintAssemblyOptions=intel` option.
 
 You will see disassembly listings for all compiled/optimized methods scrolling past you on the console, looking like this:
 
@@ -67,11 +67,11 @@ Code:
   ;   https://github.com/mraleph/irhydra/blob/master/saga/web/code.asm
 </pre>
 
-At this point I usually would take a pen and piece of paper to track control and data flow within the compiled method and just dive into it. But that evening was gloomy, GAS syntax looked more unpleasant than usual and brief inspection of the control flow inside the method revealed **three** loops instead of a single one I expected to see.
+At this point I usually would take a pen and piece of paper to track the control and data flow within the compiled method and just dive into it. But that evening was gloomy, GAS syntax looked more unpleasant than usual and brief inspection of the control flow inside the method revealed **three** loops instead of a single one I expected to see.
 
-I pondered at this for a bit and suddenly realized that the best way to verify that loops are not tripling in my eyes is to let machine do what it does best - extract control flow graph from the assembly and draw it for me.
+I pondered at this for a bit and suddenly realized that the best way to verify that loops are not tripling in my eyes is to let a machine do what it does best - extract control flow graph from the assembly and draw it for me.
 
-I already had a control flow graph display component done as part of my [IRHydra](http://mrale.ph/irhydra/2) project, so I just needed to parse disassembly listing.
+I already had a control flow graph display component done as part of my [IRHydra](http://mrale.ph/irhydra/2) project, so I just needed to parse the disassembly listing.
 
 ### "Everybody stand back. I know regular expressions."
 
@@ -79,7 +79,7 @@ Control flow graph (CFG) consists of _basic blocks_ --- chunks of code with a si
 
 <p class="sidenote-host">This definition makes CFG reconstruction algorithm obvious:<small class="sidenote">[This is an approximation, e.g. we are purposefully ignoring <em>exceptional</em> control flow.]</small></p>
 
-* find all control flow instructions (jumps, returns), these are always last instructions in a block: block can only have a single exit which means jump can't jump from inside the block.
+* find all control flow instructions (jumps, returns), these are always last instructions in a block: a block can only have a single exit which means a jump can't jump from inside the block.
 * find all instructions that are targets of some jump or immediately follow a control flow instruction - these start a block.
 
 For example:
@@ -187,15 +187,15 @@ for (var boundary in boundaries) {
 }
 {% endhighlight %}
 
-However when I run this code over the disassembly and displayed resulting CFG on IRHydra's `graph_pane`, it looked even more confusing than disassembly itself:
+However when I ran this code over the disassembly and displayed the resulting CFG on IRHydra's `graph_pane`, it looked even more confusing than the disassembly itself:
 
 <img src="/images/2015-03-29/graph0.svg" class="centered" width="400px">
 
-The most confusing thing here is not even a completely unreadable mess of control flow edges, but intense red color assigned to some blocks. IRHydra uses a [Brewer palette](http://mkweb.bcgsc.ca/brewer/) to indicate _loop nesting_: deeper nested loops are colored in more intense red. The way it selected colors here indicates that there is a loop of nesting 3 (blocks `B14`, `B15`, `B16`, `B17`). However even a quick glance on the disassembly reveals a strange thing: these blocks indeed form a loop, but they are not nested within any other loop. What's going on?
+The most confusing thing here is not even the completely unreadable mess of control flow edges, but the intense red color assigned to some blocks. IRHydra uses a [Brewer palette](http://mkweb.bcgsc.ca/brewer/) to indicate _loop nesting_: deeper nested loops are colored in more intense red. The way it selected colors here indicates that there is a loop of nesting 3 (blocks `B14`, `B15`, `B16`, `B17`). However even a quick glance on the disassembly reveals a strange thing: these blocks indeed form a loop, but they are not nested within any other loop. What's going on?
 
-Turns out that instead of a generic loop finding algorithm IRHydra was using a heuristic targeting specific shape of Dart VM and Crankshaft graphs and it failed to correctly identify loops in the CFG reconstructed from C2 generated code. The obvious next step was to replace the heuristic with some well known loop finding algorithm, for example one devised by Paul Havlak in his paper ["Nesting of reducible and irreducible loops"](http://dl.acm.org/citation.cfm?id=262005). By a lucky coincidence this algorithm was once used as a [cross-language benchmark](http://research.google.com/pubs/pub37122.html) and already has an [implementation in Dart](https://github.com/dart-lang/ton80/blob/d5fa2a386bce290c9f9d273df6e84f6b41ed576c/lib/src/Havlak/dart/Havlak.dart).
+Turns out that instead of a generic loop finding algorithm IRHydra was using a heuristic targeting the specific shape of Dart VM and Crankshaft graphs and it failed to correctly identify loops in the CFG reconstructed from C2 generated code. The obvious next step was to replace the heuristic with some well known loop finding algorithm, for example one devised by Paul Havlak in his paper ["Nesting of reducible and irreducible loops"](http://dl.acm.org/citation.cfm?id=262005). By a lucky coincidence this algorithm was once used as a [cross-language benchmark](http://research.google.com/pubs/pub37122.html) and already has an [implementation in Dart](https://github.com/dart-lang/ton80/blob/d5fa2a386bce290c9f9d273df6e84f6b41ed576c/lib/src/Havlak/dart/Havlak.dart).
 
-With loop finding heuristic replaced graph reshapes into something much closer to my initial expectations:
+With the loop finding heuristic replaced the graph reshapes into something much closer to my initial expectations:
 
 <img src="/images/2015-03-29/graph1.svg" class="centered" width="240px">
 
@@ -228,15 +228,15 @@ B33:
   jmp    B32
 {% endhighlight %}
 
-It's impossible to derive this purely from the disassembly but these `cmp`/`jae` pairs look suspiciously similar to _array bounds checks_: unsigned comparison (`jae` - _jump if above or equal_) is used to simultaneously check if index is nonnegative and is less than array's length.
+It's impossible to derive this purely from the disassembly but these `cmp`/`jae` pairs look suspiciously similar to _array bounds checks_: unsigned comparison (`jae` - _jump if above or equal_) is used to simultaneously check if the index is nonnegative and is less than the array's length.
 
 If we assume that these are indeed bounds checks then one of those two calls at the end of `B32` (most likely the second one) is either a `throw` or an _uncommon trap_ (a deoptimization). In either case control would never return back from it which means it should be treated similarly to `retq` as a block exit.
 
-Of course I could just add recognition of this call target to my mighty regular expression based parser and reconstruct CFG once again, but this leads us to a very important realization: there is always a limit to how much machine can recognize by itself, especially given an incomplete disassembly listing.
+Of course I could just add recognition of this call target to my mighty regular expression based parser and reconstruct the CFG once again, but this leads us to a very important realization: there is always a limit to how much machine can recognize by itself, especially given an incomplete disassembly listing.
 
 ## Interactivity
 
-Control-flow graph brings us only so much closer to the understanding _what kind of optimizations happened_. Ideally when reading disassembly I would like to be able to hover over register names and see where the value contained in it can be coming from. Here is a live demo of what I want to achieve:
+A control-flow graph brings us only so much closer to understanding _what kind of optimizations happened_. Ideally when reading disassembly I would like to be able to hover over register names and see where the value contained in it can be coming from. Here is a live demo of what I want to achieve:
 
 <div class="code0"></div>
 
@@ -244,7 +244,7 @@ Essentially I want to compute something known as [use-def chains](http://en.wiki
 
 ### Parsing
 
-Before I can start building use-def chains I need to parse disassembly listing completely down to the individual operands of each instruction. Regexp based "parser" was just recognizing jumps and `retq`.
+Before I can start building use-def chains I need to parse the disassembly listing completely down to the individual operands of each instruction. The regexp based "parser" was just recognizing jumps and `retq`.
 
 My favorite way of writing parsers is [parsing combinators](http://en.wikipedia.org/wiki/Parser_combinator) so I decide to go with [petiteparser](https://pub.dartlang.org/packages/petitparser) which is a Dart version of [PetiteParser](http://scg.unibe.ch/research/helvetia/petitparser) - a parser library originally developed by Lukas Renggli for Pharo Smalltalk. Here is how a parser for operand looks like:
 
@@ -264,7 +264,7 @@ final anOperand = aRegister
                 | anAddrMode;
 {% endhighlight %}
 
-After the disassembly is parsed we would run an algorithm already described above to get CFG out of it, yielding us the following structure:
+After the disassembly is parsed we would run an algorithm already described above to get the CFG out of it, yielding the following structure:
 
 {% highlight dart %}
 class BasicBlock {
@@ -313,22 +313,22 @@ Here is an example of how a DFG could look like for a simple piece of disassembl
 
 But what if at some point in the program a register contains a value that does not have a unique definition, e.g. it could be produced by several different instructions depending on the execution path taken? A simplest example would be a conditional `x = f ? 1 : 2`.
 
-Here are we again going to steal a page from a compiler construction handbook and use an abstraction called _phi-functions_ (also known as &phi;-functions in ancient Greece) used in [Single Static Assignment form](http://en.wikipedia.org/wiki/Static_single_assignment_form). Phi-function represents a data-flow merge that occurs at a control-flow merge point. Given a block with `N` predecessors a phi-function inside that block would also have `N` inputs. When "executed" phi-function essentially looks at where control came from into the its block and returns a value of the input corresponding to that predecessor.
+Here are we again going to steal a page from a compiler construction handbook and use an abstraction called _phi-functions_ (also known as &phi;-functions in ancient Greece) used in [Single Static Assignment form](http://en.wikipedia.org/wiki/Static_single_assignment_form). A phi-function represents a data-flow merge that occurs at a control-flow merge point. Given a block with `N` predecessors a phi-function inside that block would also have `N` inputs. When "executed", the phi-function essentially looks at where control came from into its block and returns the value of the input corresponding to that predecessor.
 
-<p class="sidenote-host">Consider the following example:<small class="sidenote">[Sane optimizing compiler is unlikely to generate this kind of messy machine code from the simple ternary expression above. I just wanted to keep example simple. For example LLVM would avoid branches by generating<br/><br/>
+<p class="sidenote-host">Consider the following example:<small class="sidenote">[A sane optimizing compiler is unlikely to generate this kind of messy machine code from the simple ternary expression above. I just wanted to keep the example simple. For example LLVM would avoid branches by generating<br/><br/>
 <code>cmpq $1, %rax</code><br/>
 <code>movl $1, %ebx</code><br/>
 <code>adcq $0, %rbx</code>]</small></p>
 
 <img src="/images/2015-03-29/flow-graph-phi.png" class="centered">
 
-Here the block `B3` has two predecessors `B1` and `B2`. At the end of `B1` register `%rbx` contains constant `1`. At the end of `B2` the same register `%rbx` contains value `2`. This means that at the beginning of `B3` this register contains either `1` or `2` depending on where control came from into `B3`. This is captured by a phi-function with two inputs: `Konst(1)` coming from `B1` and `Konst(2)` coming from `B2`.
+Here the block `B3` has two predecessors `B1` and `B2`. At the end of `B1` the register `%rbx` contains the constant `1`. At the end of `B2` the same register `%rbx` contains the value `2`. This means that at the beginning of `B3` this register contains either `1` or `2` depending on where control came from into `B3`. This is captured by a phi-function with two inputs: `Konst(1)` coming from `B1` and `Konst(2)` coming from `B2`.
 
 ### Decompiling into IR.
 
-How do we build our data-flow graph from the instructions? We are going to _interpret_ them. However instead of yielding actual values our interpretation will yield node (or nodes) capturing semantics of the instruction we execute. This is similar to [abstract interpretation](http://en.wikipedia.org/wiki/Abstract_interpretation) though associated formalism is completely unnecessary here.
+How do we build our data-flow graph from the instructions? We are going to _interpret_ them. However instead of yielding actual values our interpretation will yield node (or nodes) capturing semantics of the instruction we execute. This is similar to [abstract interpretation](http://en.wikipedia.org/wiki/Abstract_interpretation) though the associated formalism is completely unnecessary here.
 
-Lets take a look at how this could work for `add` instruction, assuming that we only wanted to support `addq %src, %dst` variant:
+Lets take a look at how this could work for the `add` instruction, assuming that we only wanted to support the `addq %src, %dst` variant:
 
 {% highlight dart %}
 class AbstractInterpreter {
@@ -361,13 +361,13 @@ class AbstractInterpreter {
 }
 {% endhighlight %}
 
-Actual code is more complicated because it would also need to support immediate operands, memory operands and different operand sizes. It also needs to track relationships between original `Instruction` operands and `Node` objects they resolve too.
+The actual code is more complicated because it would also need to support immediate operands, memory operands and different operand sizes. It also needs to track relationships between the original `Instruction` operands and the `Node` objects they resolve too.
 
-To decompile instruction stream into IR we just execute them block by block, instruction by instruction. `SSABuilder` class which we are using to store registers state also keeps track of the flow of values between blocks and inserts phis when necessary. When all blocks are visited we eliminate redundant phi-functions. This is essentially the same algorithm Crankshaft uses for on-the-fly SSA-form construction. For implementation details check either [sources](https://github.com/mraleph/irhydra/blob/02555865dadaa455b586ec85bfad35cd7e5c0354/saga/lib/src/flow/ssa.dart) or a paper describing similar algorithm ["Simple and Efficient Construction of Static Single Assignment Form"](https://pp.info.uni-karlsruhe.de/uploads/publikationen/braun13cc.pdf).
+To decompile the instruction stream into IR we just execute them block by block, instruction by instruction. The `SSABuilder` class which we are using to store registers state also keeps track of the flow of values between blocks and inserts phis when necessary. When all blocks are visited we eliminate redundant phi-functions. This is essentially the same algorithm Crankshaft uses for on-the-fly SSA-form construction. For implementation details check either the [sources](https://github.com/mraleph/irhydra/blob/02555865dadaa455b586ec85bfad35cd7e5c0354/saga/lib/src/flow/ssa.dart) or a paper describing a similar algorithm ["Simple and Efficient Construction of Static Single Assignment Form"](https://pp.info.uni-karlsruhe.de/uploads/publikationen/braun13cc.pdf).
 
 ## Optimizing IR for readability.
 
-After data-flow graph is constructed we can use computed information to show the flow of values between instructions in the disassembly. But what if I don't want to read disassembly at all? Maybe I could read IR instead?
+After data-flow graph is constructed we can the use computed information to show the flow of values between instructions in the disassembly. But what if I don't want to read disassembly at all? Maybe I could read IR instead?
 
 Lets take a look at the IR we computed for the block <code>B2</code>, which was already featured above:
 
@@ -388,21 +388,21 @@ Lets take a look at the IR we computed for the block <code>B2</code>, which was 
 </pre></div>
 </div>
 
-Turns out reading IR is even more unpleasant than disassembly it was computed from:
+Turns out reading IR is even more unpleasant than the disassembly it was computed from:
 
 * it contains dead code e.g. flags computations that are never used;
 * it contains low level idioms e.g. computing flags and then branching on them;
 * it contains HotSpot idioms in their lowered form e.g. `v49` is a [compressed oop](https://wikis.oracle.com/display/HotSpotInternals/CompressedOops) unpacking, but to see that you need to know how compressed oops work.
 
-Compiler engineers know that if you have a problem with your IR, then you can always solve it by adding yet another optimization pass (or another IR). This , by the way, is why I decided to use IR in the first place instead of computing UD-chains over instructions themselves: having a separate IR allows me to modify it as I please - while still having original instructions and use-def relations for them on the side.
+Compiler engineers know that if you have a problem with your IR, then you can always solve it by adding yet another optimization pass (or another IR). This, by the way, is why I decided to use IR in the first place instead of computing UD-chains over the instructions themselves: having a separate IR allows me to modify it as I please - while still having the original instructions and use-def relations for them on the side.
 
 ### Dead Code Elimination
 
-If IR node has no side effects and no uses then remove it from the IR. Check if any inputs become dead. Rinse. Repeat. The simplest implementation does not handle cycles in the data flow graph, but those should have been cleaned by C2 itself in the first place. We are mostly trying to get rid of unused `flags(...)` which we ourselves produced.
+If an IR node has no side effects and no uses then remove it from the IR. Check if any inputs become dead. Rinse. Repeat. The simplest implementation does not handle cycles in the data flow graph, but those should have been cleaned by C2 itself in the first place. We are mostly trying to get rid of unused `flags(...)` which we ourselves produced.
 
 ### Fuse conditionals
 
-Find all `OpBranch` and `OpSelect` instructions (aka ternary expressions) and fuse them with operations that compute flags for them.
+Find all `OpBranch` and `OpSelect` instructions (aka ternary expressions) and fuse them with operations that compute the flags for them.
 
 This optimization turns
 
@@ -444,7 +444,7 @@ Now lets take a look at a different block:
 
 Again this is harder to read than the disassembly: I would like to see the actual value that was spilled onto the stack by the register allocator instead of seeing a load from the stack.
 
-Turns out C2 generated code uses fixed-size frames so a very [straightforward store-to-load forwarding](https://github.com/mraleph/irhydra/blob/master/saga/lib/src/flow/locals.dart) pass for all `rsp` relative pointers easily fixes IR for us:
+Turns out, the C2 generated code uses fixed-size frames so a very [straightforward store-to-load forwarding](https://github.com/mraleph/irhydra/blob/master/saga/lib/src/flow/locals.dart) pass for all `rsp` relative pointers easily fixes the IR for us:
 
 <div class="saga-flex">
 <div class="code4"></div>
@@ -470,7 +470,7 @@ The load `v69` from the block `B4` above is quite obviously a load from an `int`
 </div></div>
 </pre></div>
 
-Disassembly header tells us that `this` is an instance `javabench.SmallMap`:
+The disassembly header tells us that `this` is an instance of `javabench.SmallMap`:
 
 <pre>
   # this:     rsi:rsi   = 'javabench/SmallMap'
@@ -478,7 +478,7 @@ Disassembly header tells us that `this` is an instance `javabench.SmallMap`:
 
 but it does not contain any information about its layout which prevents us from determining what `*(this + 20)` means.
 
-As you've probably heard before in Java most problems usually have three letter solutions. This one is not an exception: a tool called [JOL](http://openjdk.java.net/projects/code-tools/jol/) can fetch object layout information for you using dark arts of `sun.misc.Unsafe`.
+As you've probably heard before in Java most problems usually have three letter solutions. This one is not an exception: a tool called [JOL](http://openjdk.java.net/projects/code-tools/jol/) can fetch the object layout information for you using dark arts of `sun.misc.Unsafe`.
 
 Here is what it prints for `javabench.SmallMap`:
 
@@ -516,7 +516,7 @@ Now this is way more readable than original disassembly!
 
 It's pretty hard to figure out the best way to render data-flow graph: e.g. should a node be given a name or should it be displayed _inline_ within another node? Instead of trying to solve this in a generic way I decided to make it possible to inline and un-inline nodes with a single click.
 
-Another hard problem is giving meaningful names to individual nodes, it impossible to do it automatically. That's why any node can be renamed with a double-click.
+Another hard problem is giving meaningful names to individual nodes, it is impossible to do it automatically. That's why any node can be renamed with a double-click.
 
 Here is a fragment of the Saga UI for IR:
 
@@ -541,7 +541,7 @@ Here is a CFG after such fusion (dashed edges are unlikely ones):
 
 Ok, we have a tool that allows us to navigate IR in various ways. Maybe it's time to figure out what C2 did to that loop and why there are three loops in a method that only had one loop to begin with?
 
-If we inspect the bodies of these three loops we will find that the middle one has no array bounds checks inside while the _pre_ loop and _post_ loop have these checks. What C2 did here is the [Range Check Elimination](https://wikis.oracle.com/display/HotSpotInternals/RangeCheckElimination) optimization that splits loop iteration space into three parts in such a way that main loop (one in the middle) does not need to perform array bounds checks.
+If we inspect the bodies of these three loops we will find that the middle one has no array bounds checks inside while the _pre_ loop and _post_ loop have these checks. What C2 did here is the [Range Check Elimination](https://wikis.oracle.com/display/HotSpotInternals/RangeCheckElimination) optimization that splits the loop iteration space into three parts in such a way that main loop (one in the middle) does not need to perform array bounds checks.
 
 We start with a loop like this:
 
@@ -570,11 +570,11 @@ for (int i = 0; ; i++) {
 }
 {% endhighlight %}
 
-As far as I can guess C2 thinks that iteration space of this loop is `[0, L)` so it splits it into three loops:
+As far as I can guess C2 thinks that the iteration space of this loop is `[0, L)` so it splits it into three loops:
 
-* pre-loop going from `0` to `min(max(S - L, 1), L)`.
-* main-loop continuing from there to `min(S, L)`
-* post-loop continuing from there to `L`.
+* a pre-loop going from `0` to `min(max(S - L, 1), L)`.
+* a main-loop continuing from there to `min(S, L)`
+* a post-loop continuing from there to `L`.
 
 These bounds mean that the body of the main loop is executing only for values of `i` such that `0 <= max(S - L, 1) <= i < min(S, L)`. This immediately yields `S > 0`. (note: `S - 1 > 0` checked before the loop does not imply `S >= 0` as `S - 1` could have overflowed if `S = INT_MIN`).
 
@@ -583,7 +583,7 @@ These bounds mean that the body of the main loop is executing only for values of
 
 In other words we have shown that `0 <= S - 1 - i < L`. `0 <= i < L` is obvious. This means the main loop can skip both range checks.
 
-Ultimately for this particular loop it removes only one conditional branch because after this optimization the loop *still* checks both old loop condition `i <= j` and new artificial loop condition `i < min(S, L)`. Another funny thing is that in the post-loop that goes up to `L` we still perform the bounds check on `i` even though it should not be necessary (though that does not really matter as in the well behaved code most of the time should be spent in the main loop anyway). I suspect that this optimization works better when the original loop condition has a loop invariant limit.
+Ultimately for this particular loop it removes only one conditional branch because after this optimization the loop *still* checks both, the old loop condition `i <= j` and a new artificial loop condition `i < min(S, L)`. Another funny thing is that in the post-loop that goes up to `L` we still perform the bounds check on `i` even though it should not be necessary (though that does not really matter as in the well behaved code most of the time should be spent in the main loop anyway). I suspect that this optimization works better when the original loop condition has a loop invariant limit.
 
 <small>[Anybody who is more familiar with HotSpot internals should correct me if I am wrong in my reasoning above, as I only glanced through [`do_range_check` phase](http://hg.openjdk.java.net/jdk9/dev/hotspot/file/8f6b400b6453/src/share/vm/opto/loopTransform.cpp#l1776) in C2 sources but that's too much code to grasp it quickly]</small>
 


### PR DESCRIPTION
The title could stay the same.
I'm unsure about "hardwired for" and "hardwired to" but "to" seems to be more frequent.
The use of IR is not completely consistent. You could go through it and add "the"/"an" in many places, but it reads ok without them.
Maybe: s/for using dark arts of `sun.misc.Unsafe`/for use in the dark arts of .../ ?